### PR TITLE
Fix package name in README documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Integrate SMTP2Go directly into your application using SMTP2Go's API
 ### Installation
 
 ```bash
-composer require motomedialab/laravel-smtp2go
+composer require motomedialab/smtp2go
 ```
 
 ### Configuration


### PR DESCRIPTION
This should resolved #4 as the instructions and packagist name are different