### PR TITLE
fix(smtp2go): ensure compatibility with PHP 8.4 constructor behavior

### DIFF
--- a/src/Transports/Smtp2GoTransport.php
+++ b/src/Transports/Smtp2GoTransport.php
@@ -21,7 +21,7 @@ class Smtp2GoTransport extends AbstractTransport
 
     protected string $endpoint = 'https://api.smtp2go.com/v3/email/send';
 
-    public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
+    public function __construct(?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null)
     {
         parent::__construct($dispatcher, $logger);
 


### PR DESCRIPTION
Updated the constructor in `Smtp2GoTransport` to use nullable type hints for parameters. This change eliminates potential type errors and improves compatibility with PHP 8.4.