### PR TITLE
feat(composer): add support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.0",
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
Extended the version constraint for "laravel/framework" to include support for version 13. This ensures compatibility with Laravel 13 without breaking existing support.

refs: chore/laravel13-support