### PR TITLE
Record SMTP2Go's email_id on the SentMessage

### DIFF
--- a/src/Transports/Smtp2GoTransport.php
+++ b/src/Transports/Smtp2GoTransport.php
@@ -67,6 +67,23 @@ class Smtp2GoTransport extends AbstractTransport
             throw Smtp2GoException::make('Failed to send via '.$this.' transport', $response->status())
                 ->setContext(['data' => $data, 'error' => $response->json()]);
         }
+
+        $this->recordMessageId($message, $response->json('data.email_id'));
+    }
+
+    /**
+     * Record the identifier SMTP2Go assigned to the sent message.
+     *
+     * This is the value SMTP2Go echoes back on its delivery webhooks, so it is
+     * the only way to tie a webhook event to the send that produced it. Storing
+     * it on the SentMessage follows the Symfony convention and surfaces it on
+     * Laravel's MessageSent event via $event->sent->getMessageId().
+     */
+    protected function recordMessageId(SentMessage $message, mixed $emailId): void
+    {
+        if (is_string($emailId) && $emailId !== '') {
+            $message->setMessageId($emailId);
+        }
     }
 
     /**

--- a/tests/Feature/EmailCanBeSentTest.php
+++ b/tests/Feature/EmailCanBeSentTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature;
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\Message;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -48,5 +50,71 @@ class EmailCanBeSentTest extends TestCase
             && $request['sender'] === 'Testing! <test@test.com>'
             && $request['subject'] === 'test'
             && $request['text_body'] === 'Testing');
+    }
+
+    public function test_smtp2go_email_id_is_recorded_on_the_sent_message()
+    {
+        Http::fake([
+            '*' => Http::response([
+                'data' => [
+                    'succeeded' => [
+                        'test@test.com'
+                    ],
+                    'email_id' => '1abcde-fghij-2klmno',
+                ]
+            ])
+        ]);
+
+        $sent = Mail::driver('smtp2go')->raw('Testing', function (Message $message) {
+            $message->to('test@test.com')->subject('test');
+        });
+
+        $this->assertSame('1abcde-fghij-2klmno', $sent->getMessageId());
+    }
+
+    public function test_smtp2go_message_id_is_left_alone_when_the_api_returns_no_email_id()
+    {
+        Http::fake([
+            '*' => Http::response([
+                'data' => [
+                    'succeeded' => [
+                        'test@test.com'
+                    ]
+                ]
+            ])
+        ]);
+
+        $sent = Mail::driver('smtp2go')->raw('Testing', function (Message $message) {
+            $message->to('test@test.com')->subject('test');
+            $message->getSymfonyMessage()->getHeaders()->addIdHeader('Message-ID', 'control@test.com');
+        });
+
+        $this->assertSame('control@test.com', $sent->getMessageId());
+    }
+
+    public function test_smtp2go_email_id_is_available_on_the_message_sent_event()
+    {
+        Http::fake([
+            '*' => Http::response([
+                'data' => [
+                    'succeeded' => [
+                        'test@test.com'
+                    ],
+                    'email_id' => '1abcde-fghij-2klmno',
+                ]
+            ])
+        ]);
+
+        $messageId = null;
+
+        Event::listen(function (MessageSent $event) use (&$messageId) {
+            $messageId = $event->sent->getMessageId();
+        });
+
+        Mail::driver('smtp2go')->raw('Testing', function (Message $message) {
+            $message->to('test@test.com')->subject('test');
+        });
+
+        $this->assertSame('1abcde-fghij-2klmno', $messageId);
     }
 }


### PR DESCRIPTION
`doSend()` currently discards the send API's response body. That response carries SMTP2Go's `email_id`, which is the identifier its delivery webhooks echo back — so there is currently no way to tie an inbound `delivered` / `bounce` / `spam` webhook to the send that produced it without reimplementing the whole transport to get at the response.

This sets that id on the `SentMessage`.

## Why this shape

Symfony's API-based transports already have a convention for exactly this: Mailgun, Postmark and SES all call `$sentMessage->setMessageId(...)` with the provider's identifier from the send response. Conforming to it means no new public API on this package, and the id surfaces through the paths people already use:

```php
// returned from the mailer
$id = Mail::mailer('smtp2go')->send(new OrderShipped($order))->getMessageId();

// or on Laravel's MessageSent event, alongside the original headers
Event::listen(function (MessageSent $event) {
    $event->sent->getMessageId();
});
```

I considered returning the raw response or dispatching a package-specific event instead, but both add surface area for something the framework already models.

## Backwards compatibility

`SentMessage` seeds its message id from the MIME `Message-ID` header, and overwriting it is the documented contract for a transport — `setMessageId()` is described as *"Sets the transport-level message ID"*, and `getMessageId()` carries the note *"Not to be confused with the Message-ID header, which is available via getOriginalMessage()"*. So this fills in a value that is currently a placeholder rather than replacing anything meaningful, and the MIME header itself is untouched either way.

The id is only set when SMTP2Go returns a non-empty string, so a response without an `email_id` leaves the existing behaviour exactly as it is.

## Tests

Three tests added to the existing feature file:

- the `email_id` is recorded on the returned `SentMessage`
- it is readable from Laravel's `MessageSent` event
- a response with no `email_id` leaves the message id at the MIME `Message-ID`

The existing request-shape test is unmodified and still passes. `setMessageId()` is present in symfony/mailer 5.4 through 7.x and `MessageSent::$sent` in Laravel 9 onwards, so this should hold across the full CI matrix.