### PR TITLE
Send the API key as a header and keep message content out of failure logs

### DIFF
--- a/src/Transports/Smtp2GoTransport.php
+++ b/src/Transports/Smtp2GoTransport.php
@@ -40,7 +40,6 @@ class Smtp2GoTransport extends AbstractTransport
 
         // build our data to send to the API.
         $data = collect([
-            'api_key' => config('mail.mailers.smtp2go.api_key'),
             'to' => $this->sanitiseAddresses($email->getTo())->all(),
             'cc' => $this->sanitiseAddresses($email->getCc())->all(),
             'bcc' => $this->sanitiseAddresses($email->getBcc())->all(),
@@ -61,11 +60,17 @@ class Smtp2GoTransport extends AbstractTransport
             ])->all(),
         ])->filter()->all();
 
-        $response = Http::timeout(60)->post($this->endpoint, $data);
+        $response = Http::timeout(60)
+            ->withHeaders(['X-Smtp2go-Api-Key' => (string) config('mail.mailers.smtp2go.api_key')])
+            ->post($this->endpoint, $data);
 
         if (! $response->successful() || $response->json('data.succeeded') < 1) {
             throw Smtp2GoException::make('Failed to send via '.$this.' transport', $response->status())
-                ->setContext(['data' => $data, 'error' => $response->json()]);
+                ->setContext([
+                    'status' => $response->status(),
+                    'data' => $this->summarisePayload($data),
+                    'error' => $response->json(),
+                ]);
         }
 
         $this->recordMessageId($message, $response->json('data.email_id'));
@@ -84,6 +89,31 @@ class Smtp2GoTransport extends AbstractTransport
         if (is_string($emailId) && $emailId !== '') {
             $message->setMessageId($emailId);
         }
+    }
+
+    /**
+     * Summarise the payload for the exception context of a failed send.
+     *
+     * Laravel merges an exception's context into its log entry, so this is an
+     * allowlist of metadata that helps diagnose a failure without writing the
+     * message content, recipient addresses or attachment data to the logs.
+     */
+    protected function summarisePayload(array $data): array
+    {
+        return [
+            'sender' => $data['sender'] ?? null,
+            'subject' => $data['subject'] ?? null,
+            'recipients' => [
+                'to' => count($data['to'] ?? []),
+                'cc' => count($data['cc'] ?? []),
+                'bcc' => count($data['bcc'] ?? []),
+            ],
+            'attachments' => array_map(fn (array $attachment): array => [
+                'filename' => $attachment['filename'],
+                'mimetype' => $attachment['mimetype'],
+                'size' => strlen(base64_decode($attachment['fileblob'])),
+            ], $data['attachments'] ?? []),
+        ];
     }
 
     /**

--- a/tests/Feature/EmailCanBeSentTest.php
+++ b/tests/Feature/EmailCanBeSentTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
+use Motomedialab\Smtp2Go\Exceptions\Smtp2GoException;
 use Tests\TestCase;
 
 class EmailCanBeSentTest extends TestCase
@@ -45,7 +46,7 @@ class EmailCanBeSentTest extends TestCase
         });
 
         Http::assertSent(fn (Request $request) => $request->url() === 'https://api.smtp2go.com/v3/email/send'
-            && $request['api_key'] === 'test_key'
+            && $request->hasHeader('X-Smtp2go-Api-Key', 'test_key')
             && $request['to'] === ['test@test.com']
             && $request['sender'] === 'Testing! <test@test.com>'
             && $request['subject'] === 'test'
@@ -116,5 +117,105 @@ class EmailCanBeSentTest extends TestCase
         });
 
         $this->assertSame('1abcde-fghij-2klmno', $messageId);
+    }
+
+    public function test_smtp2go_api_key_is_sent_in_a_header_rather_than_the_body()
+    {
+        Http::fake([
+            '*' => Http::response([
+                'data' => [
+                    'succeeded' => [
+                        'test@test.com'
+                    ]
+                ]
+            ])
+        ]);
+
+        Mail::driver('smtp2go')->raw('Testing', function (Message $message) {
+            $message->to('test@test.com')->subject('test');
+        });
+
+        Http::assertSent(fn (Request $request) => $request->hasHeader('X-Smtp2go-Api-Key', 'test_key')
+            && ! array_key_exists('api_key', $request->data()));
+    }
+
+    public function test_smtp2go_failure_context_excludes_the_api_key_and_message_content()
+    {
+        Http::fake([
+            '*' => Http::response($this->errorResponse(), 400)
+        ]);
+
+        $context = json_encode($this->sendFailingMessage()->context());
+
+        Http::assertSent(fn (Request $request) => $request['text_body'] === 'Secret text body'
+            && $request['html_body'] === '<p>Secret html body</p>'
+            && str_contains($request['attachments'][0]['fileblob'], base64_encode('Secret attachment')));
+
+        $this->assertStringNotContainsString('test_key', $context);
+        $this->assertStringNotContainsString('Secret text body', $context);
+        $this->assertStringNotContainsString('Secret html body', $context);
+        $this->assertStringNotContainsString('Secret attachment', $context);
+        $this->assertStringNotContainsString(base64_encode('Secret attachment'), $context);
+        $this->assertStringNotContainsString('customer@example.com', $context);
+    }
+
+    public function test_smtp2go_failure_context_keeps_what_is_needed_to_debug_the_failure()
+    {
+        Http::fake([
+            '*' => Http::response($this->errorResponse(), 400)
+        ]);
+
+        $exception = $this->sendFailingMessage();
+        $sent = Http::recorded()->first()[0];
+
+        $this->assertSame(400, $exception->getCode());
+        $this->assertSame([
+            'status' => 400,
+            'data' => [
+                'sender' => 'Testing! <test@test.com>',
+                'subject' => 'test',
+                'recipients' => [
+                    'to' => 2,
+                    'cc' => 1,
+                    'bcc' => 0,
+                ],
+                'attachments' => [
+                    [
+                        'filename' => 'invoice.pdf',
+                        'mimetype' => $sent['attachments'][0]['mimetype'],
+                        'size' => 17,
+                    ],
+                ],
+            ],
+            'error' => $this->errorResponse(),
+        ], $exception->context());
+    }
+
+    protected function sendFailingMessage(): Smtp2GoException
+    {
+        try {
+            Mail::driver('smtp2go')->raw('Secret text body', function (Message $message) {
+                $message->to(['customer@example.com', 'another@example.com'])
+                    ->cc('manager@example.com')
+                    ->subject('test');
+                $message->html('<p>Secret html body</p>');
+                $message->attachData('Secret attachment', 'invoice.pdf', ['mime' => 'application/pdf']);
+            });
+        } catch (Smtp2GoException $exception) {
+            return $exception;
+        }
+
+        $this->fail('Expected the send to throw a Smtp2GoException.');
+    }
+
+    protected function errorResponse(): array
+    {
+        return [
+            'request_id' => '22e5acba-43bf-11e6-ae42-408d5cce2644',
+            'data' => [
+                'error_code' => 'E_ApiResponseCodes.ENDPOINT_PERMISSION_DENIED',
+                'error' => 'You do not have permission to access this API endpoint',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Two related fixes in `Smtp2GoTransport::doSend()`, both about where the API key and message content end up.

## Authenticate with the `X-Smtp2go-Api-Key` header

The transport currently sends the key as an `api_key` field in the JSON body. SMTP2Go's [API reference for `/email/send`](https://developers.smtp2go.com/reference/send-standard-email) documents authentication only via the `X-Smtp2go-Api-Key` request header (or a bearer token) — there's no body field for it. This moves the key into that header and removes it from the body.

The key is still read from `mail.mailers.smtp2go.api_key`, so nobody needs to touch their config or `.env`.

## Stop logging the payload when a send fails

On failure the transport throws with `setContext(['data' => $data, ...])`, where `$data` is the entire request. Laravel's exception handler merges an exception's `context()` into the log entry, so every failed send currently writes the API key, the full HTML and text bodies, recipient addresses and base64 attachments to the application log — and on to whatever error tracker is reading it.

The context now keeps what's useful for diagnosing a failure and nothing else:

```php
[
    'status' => 400,
    'data' => [
        'sender' => 'Example App <hello@example.com>',
        'subject' => 'Your invoice',
        'recipients' => ['to' => 2, 'cc' => 1, 'bcc' => 0],
        'attachments' => [
            ['filename' => 'invoice.pdf', 'mimetype' => 'application', 'size' => 48213],
        ],
    ],
    'error' => [/* SMTP2Go's response, unchanged: request_id, data.error, data.error_code */],
]
```

`data` is built as an allowlist rather than by stripping fields out of the payload, so anything added to the request in future stays out of the logs by default. `error` is SMTP2Go's response verbatim, so the `request_id` is still there for support tickets.

One judgement call I'd welcome your view on: I've logged recipient **counts** rather than addresses, since addresses are personal data and usually the thing people least want in a third-party error tracker. Happy to switch to addresses if you'd rather have them for debugging. The sender is kept, as it's the app's own address and is often what a failure is about.

## Backwards compatibility

- No config changes: same key, same `.env` variable.
- Successful sends behave exactly as before, including the `email_id` recording from #14.
- The exception class, message and code (the HTTP status) are unchanged, and `context()` keeps its `data` and `error` keys. The only difference is that `data` no longer carries the key, bodies, addresses or attachment contents, which is the point.

## Tests

- The existing request-shape test now asserts the key is in the header rather than the body
- the API key is sent in `X-Smtp2go-Api-Key` and there is no `api_key` in the body
- a failed send's context contains no API key, text or HTML body, attachment content or recipient addresses — the test also asserts those *were* in the request, so it can't pass vacuously
- the context keeps the status, SMTP2Go's error response, sender, subject, recipient counts and attachment metadata

The #14 tests are unmodified and pass. I've run the suite against Laravel 13 and Laravel 9, and Pint passes with the repo's config.

## Possible follow-ups

Both out of scope here, but happy to send separate PRs if they're of interest:

- The endpoint is hard-coded to the regionless `api.smtp2go.com`; SMTP2Go also offers [regional endpoints](https://developers.smtp2go.com/reference/send-standard-email) (`us-`, `eu-` and `au-api.smtp2go.com`), which could be a config option.
- While writing the tests I noticed attachments are sent with `'mimetype' => $attachment->getMediaType()`, which is only the top-level type (`application` for a PDF) rather than `getContentType()` (`application/pdf`). It's a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
